### PR TITLE
Add option to hide shulker box model behind hint in GUI

### DIFF
--- a/src/main/java/de/maxhenkel/peek/config/PeekConfig.java
+++ b/src/main/java/de/maxhenkel/peek/config/PeekConfig.java
@@ -27,6 +27,7 @@ public class PeekConfig {
     public final ConfigEntry<Boolean> useShulkerBoxDataStrings;
     public final ConfigEntry<Boolean> useShulkerBoxItemNames;
     public final ConfigEntry<ShulkerItemDisplayType> shulkerBoxItemDisplayType;
+    public final ConfigEntry<Boolean> hideShulkerBoxItemBehindHint;
     public final ConfigEntry<Boolean> hideShulkerBoxDataStrings;
     public final ConfigEntry<Boolean> sendShulkerBoxDataToClient;
 
@@ -135,6 +136,11 @@ public class PeekConfig {
                 "SINGLE_TYPE: If the shulker box only contains one type of item, show that item",
                 "BULK: Show the item thats most common in the shulker box",
                 "FIRST_ITEM: Show the first item in the shulker box"
+        );
+        hideShulkerBoxItemBehindHint = builder.booleanEntry(
+                "hide_shulker_box_item_behind_hint",
+                false,
+                "If this is enabled, the shulker box model will not be rendered behind the item hint in the inventory"
         );
         hideShulkerBoxDataStrings = builder.booleanEntry(
                 "hide_shulker_box_data_strings",

--- a/src/main/java/de/maxhenkel/peek/integration/ClothConfigIntegration.java
+++ b/src/main/java/de/maxhenkel/peek/integration/ClothConfigIntegration.java
@@ -122,6 +122,12 @@ public class ClothConfigIntegration {
                 Peek.CONFIG.showShulkerBoxLabels
         ));
 
+        shulkerBoxHints.addEntry(fromConfigEntry(entryBuilder,
+                Component.translatable("cloth_config.peek.hide_shulker_box_item_behind_hint"),
+                Component.translatable("cloth_config.peek.hide_shulker_box_item_behind_hint.description"),
+                Peek.CONFIG.hideShulkerBoxItemBehindHint
+        ));
+
         ConfigCategory decoratedPotHints = builder.getOrCreateCategory(Component.translatable("cloth_config.peek.category.decorated_pot_hints"));
 
         decoratedPotHints.addEntry(fromConfigEntry(entryBuilder,

--- a/src/main/java/de/maxhenkel/peek/mixin/ShulkerBoxSpecialRendererMixin.java
+++ b/src/main/java/de/maxhenkel/peek/mixin/ShulkerBoxSpecialRendererMixin.java
@@ -29,7 +29,9 @@ public abstract class ShulkerBoxSpecialRendererMixin implements SpecialModelRend
 
     @Override
     public void submit(@Nullable ShulkerHintData data, ItemDisplayContext itemDisplayContext, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int light, int overlay, boolean bl, int k) {
-        submit(itemDisplayContext, poseStack, submitNodeCollector, light, overlay, bl, k);
+        if (!Peek.CONFIG.hideShulkerBoxItemBehindHint.get() || itemDisplayContext != ItemDisplayContext.GUI || data == null || data.getDisplayItem() == null) {
+            submit(itemDisplayContext, poseStack, submitNodeCollector, light, overlay, bl, k);
+        }
         if (!Peek.CONFIG.showShulkerBoxItemHint.get()) {
             return;
         }

--- a/src/main/resources/assets/peek/lang/de_de.json
+++ b/src/main/resources/assets/peek/lang/de_de.json
@@ -54,6 +54,8 @@
   "cloth_config.peek.shulker_box_item_display_type.first_item.description": "Zeigt den ersten Gegenstand in der Shulker-Kiste an",
   "cloth_config.peek.show_shulker_box_labels": "Shulker-Kisten Namen anzeigen",
   "cloth_config.peek.show_shulker_box_labels.description": "Ob der Mod den benutzerdefinierten Namen der Shulker-Box auf dem Deckel der Shulker Box anzeigen soll.",
+  "cloth_config.peek.hide_shulker_box_item_behind_hint": "Shulker-Kiste hinter Hinweis ausblenden",
+  "cloth_config.peek.hide_shulker_box_item_behind_hint.description": "Wenn aktiviert, wird das Shulker-Kisten-Modell im Inventar nicht hinter dem Gegenstandshinweis angezeigt.",
   "cloth_config.peek.show_decorated_pot_hint": "Hinweis für verzierte Krüge anzeigen",
   "cloth_config.peek.show_decorated_pot_hint.description": "Ob Informationen zum Gegenstand in dekorierten Krügen angezeigt werden sollen."
 }

--- a/src/main/resources/assets/peek/lang/en_us.json
+++ b/src/main/resources/assets/peek/lang/en_us.json
@@ -54,6 +54,8 @@
   "cloth_config.peek.shulker_box_item_display_type.first_item.description": "Show the first item in the shulker box",
   "cloth_config.peek.show_shulker_box_labels": "Show Shulker Box Labels",
   "cloth_config.peek.show_shulker_box_labels.description": "If this is enabled, the mod will show the custom name of the Shulker Box on the lid of the shulker box.",
+  "cloth_config.peek.hide_shulker_box_item_behind_hint": "Hide Shulker Box Behind Hint",
+  "cloth_config.peek.hide_shulker_box_item_behind_hint.description": "If this is enabled, the shulker box model will not be rendered behind the item hint in the inventory.",
   "cloth_config.peek.show_decorated_pot_hint": "Show Decorated Pot Hint",
   "cloth_config.peek.show_decorated_pot_hint.description": "If this is enabled, decorated pots will show the contained item and amount."
 }


### PR DESCRIPTION
This option allows players to display only the item hint of a shulker box in the inventory or chests, as it removes the shulker box icon used as the slot's background. Useful when the built-in resource pack is activated.

<img width="1906" height="677" alt="image" src="https://github.com/user-attachments/assets/593fbe55-7e4e-4c17-a88b-c9d6c7dd2ab0" />

<img width="456" height="200" alt="image" src="https://github.com/user-attachments/assets/8ade058c-ba6d-4e3e-8e74-de4580c760b8" />