### PR TITLE
Add configurable scale for shulker box hint item in GUI

### DIFF
--- a/src/main/java/de/maxhenkel/peek/config/PeekConfig.java
+++ b/src/main/java/de/maxhenkel/peek/config/PeekConfig.java
@@ -27,6 +27,7 @@ public class PeekConfig {
     public final ConfigEntry<Boolean> useShulkerBoxDataStrings;
     public final ConfigEntry<Boolean> useShulkerBoxItemNames;
     public final ConfigEntry<ShulkerItemDisplayType> shulkerBoxItemDisplayType;
+    public final ConfigEntry<Integer> shulkerBoxHintItemScale;
     public final ConfigEntry<Boolean> hideShulkerBoxDataStrings;
     public final ConfigEntry<Boolean> sendShulkerBoxDataToClient;
 
@@ -135,6 +136,13 @@ public class PeekConfig {
                 "SINGLE_TYPE: If the shulker box only contains one type of item, show that item",
                 "BULK: Show the item thats most common in the shulker box",
                 "FIRST_ITEM: Show the first item in the shulker box"
+        );
+        shulkerBoxHintItemScale = builder.integerEntry(
+                "shulker_box_hint_item_scale",
+                100,
+                50,
+                200,
+                "The scale of the item hint on shulker boxes in the inventory in percent"
         );
         hideShulkerBoxDataStrings = builder.booleanEntry(
                 "hide_shulker_box_data_strings",

--- a/src/main/java/de/maxhenkel/peek/events/ShulkerRenderEvents.java
+++ b/src/main/java/de/maxhenkel/peek/events/ShulkerRenderEvents.java
@@ -31,15 +31,15 @@ public class ShulkerRenderEvents {
         if (!(shulkerBoxRenderState instanceof PeekShulkerBoxRenderState peekState)) {
             throw new IllegalStateException("ShulkerBoxRenderState is not a PeekShulkerBoxRenderState");
         }
-        submitShulkerBoxLabel(shulkerBoxRenderState.direction, shulkerBoxRenderState.progress, peekState.peek$getDisplayItem(), peekState.peek$getLabel(), shulkerBoxRenderState.lightCoords, poseStack, submitNodeCollector);
+        submitShulkerBoxLabel(shulkerBoxRenderState.direction, shulkerBoxRenderState.progress, peekState.peek$getDisplayItem(), peekState.peek$getLabel(), shulkerBoxRenderState.lightCoords, poseStack, submitNodeCollector, 1F);
     }
 
-    public static void submitShulkerBoxItemLabel(ShulkerHintData shulkerHintData, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int light) {
+    public static void submitShulkerBoxItemLabel(ShulkerHintData shulkerHintData, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int light, float itemScale) {
         ItemStackRenderState itemStackRenderState = ItemRenderUtils.fromStack(Minecraft.getInstance().level, null, createShulkerRenderStack(shulkerHintData.getDisplayItem()));
-        submitShulkerBoxLabel(Direction.UP, 0F, itemStackRenderState, shulkerHintData.getLabelFormatted(), light, poseStack, submitNodeCollector);
+        submitShulkerBoxLabel(Direction.UP, 0F, itemStackRenderState, shulkerHintData.getLabelFormatted(), light, poseStack, submitNodeCollector, itemScale);
     }
 
-    private static void submitShulkerBoxLabel(Direction direction, float progress, @Nullable ItemStackRenderState displayItem, @Nullable FormattedCharSequence label, int lightCoords, PoseStack poseStack, SubmitNodeCollector submitNodeCollector) {
+    private static void submitShulkerBoxLabel(Direction direction, float progress, @Nullable ItemStackRenderState displayItem, @Nullable FormattedCharSequence label, int lightCoords, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, float itemScale) {
         Minecraft mc = Minecraft.getInstance();
 
         poseStack.pushPose();
@@ -57,6 +57,9 @@ public class ShulkerRenderEvents {
             if (label != null) {
                 poseStack.translate(0F, 2F / 16F, 0F);
                 poseStack.scale(12F / 16F, 12F / 16F, 12F / 16F);
+            }
+            if (itemScale != 1F) {
+                poseStack.scale(itemScale, itemScale, itemScale);
             }
             displayItem.submit(poseStack, submitNodeCollector, lightCoords, OverlayTexture.NO_OVERLAY, 0);
             poseStack.popPose();

--- a/src/main/java/de/maxhenkel/peek/integration/ClothConfigIntegration.java
+++ b/src/main/java/de/maxhenkel/peek/integration/ClothConfigIntegration.java
@@ -122,6 +122,12 @@ public class ClothConfigIntegration {
                 Peek.CONFIG.showShulkerBoxLabels
         ));
 
+        shulkerBoxHints.addEntry(fromConfigEntry(entryBuilder,
+                Component.translatable("cloth_config.peek.shulker_box_hint_item_scale"),
+                Component.translatable("cloth_config.peek.shulker_box_hint_item_scale.description"),
+                Peek.CONFIG.shulkerBoxHintItemScale
+        ));
+
         ConfigCategory decoratedPotHints = builder.getOrCreateCategory(Component.translatable("cloth_config.peek.category.decorated_pot_hints"));
 
         decoratedPotHints.addEntry(fromConfigEntry(entryBuilder,

--- a/src/main/java/de/maxhenkel/peek/mixin/ShulkerBoxSpecialRendererMixin.java
+++ b/src/main/java/de/maxhenkel/peek/mixin/ShulkerBoxSpecialRendererMixin.java
@@ -34,7 +34,8 @@ public abstract class ShulkerBoxSpecialRendererMixin implements SpecialModelRend
             return;
         }
         if (data != null) {
-            ShulkerRenderEvents.submitShulkerBoxItemLabel(data, poseStack, submitNodeCollector, light);
+            float itemScale = itemDisplayContext == ItemDisplayContext.GUI ? Peek.CONFIG.shulkerBoxHintItemScale.get() / 100F : 1F;
+            ShulkerRenderEvents.submitShulkerBoxItemLabel(data, poseStack, submitNodeCollector, light, itemScale);
         }
     }
 

--- a/src/main/resources/assets/peek/lang/de_de.json
+++ b/src/main/resources/assets/peek/lang/de_de.json
@@ -54,6 +54,8 @@
   "cloth_config.peek.shulker_box_item_display_type.first_item.description": "Zeigt den ersten Gegenstand in der Shulker-Kiste an",
   "cloth_config.peek.show_shulker_box_labels": "Shulker-Kisten Namen anzeigen",
   "cloth_config.peek.show_shulker_box_labels.description": "Ob der Mod den benutzerdefinierten Namen der Shulker-Box auf dem Deckel der Shulker Box anzeigen soll.",
+  "cloth_config.peek.shulker_box_hint_item_scale": "Hinweis-Gegenstand Skalierung",
+  "cloth_config.peek.shulker_box_hint_item_scale.description": "Die Skalierung des Gegenstandshinweises auf Shulker-Kisten im Inventar in Prozent.",
   "cloth_config.peek.show_decorated_pot_hint": "Hinweis für verzierte Krüge anzeigen",
   "cloth_config.peek.show_decorated_pot_hint.description": "Ob Informationen zum Gegenstand in dekorierten Krügen angezeigt werden sollen."
 }

--- a/src/main/resources/assets/peek/lang/en_us.json
+++ b/src/main/resources/assets/peek/lang/en_us.json
@@ -54,6 +54,8 @@
   "cloth_config.peek.shulker_box_item_display_type.first_item.description": "Show the first item in the shulker box",
   "cloth_config.peek.show_shulker_box_labels": "Show Shulker Box Labels",
   "cloth_config.peek.show_shulker_box_labels.description": "If this is enabled, the mod will show the custom name of the Shulker Box on the lid of the shulker box.",
+  "cloth_config.peek.shulker_box_hint_item_scale": "Hint Item Scale",
+  "cloth_config.peek.shulker_box_hint_item_scale.description": "The scale of the item hint on shulker boxes in the inventory in percent.",
   "cloth_config.peek.show_decorated_pot_hint": "Show Decorated Pot Hint",
   "cloth_config.peek.show_decorated_pot_hint.description": "If this is enabled, decorated pots will show the contained item and amount."
 }


### PR DESCRIPTION
This option allows players to change the item hint's size on shulker boxes in inventory and chests. Can be useful for full blocks that are rendered smaller on shulker hints.

<img width="1885" height="550" alt="image" src="https://github.com/user-attachments/assets/3be6c780-26aa-47b5-a4cb-ed700270bbed" />

Cobblestone shulker in 200% size:
<img width="46" height="44" alt="image" src="https://github.com/user-attachments/assets/1aaefa9f-a126-4aed-8dd4-fab1cfbdc1e7" />
