### PR TITLE
Add fill bar for shulker boxes in inventory

### DIFF
--- a/src/main/java/de/maxhenkel/peek/config/PeekConfig.java
+++ b/src/main/java/de/maxhenkel/peek/config/PeekConfig.java
@@ -27,6 +27,7 @@ public class PeekConfig {
     public final ConfigEntry<Boolean> useShulkerBoxDataStrings;
     public final ConfigEntry<Boolean> useShulkerBoxItemNames;
     public final ConfigEntry<ShulkerItemDisplayType> shulkerBoxItemDisplayType;
+    public final ConfigEntry<Boolean> showShulkerBoxFillBar;
     public final ConfigEntry<Boolean> hideShulkerBoxDataStrings;
     public final ConfigEntry<Boolean> sendShulkerBoxDataToClient;
 
@@ -135,6 +136,11 @@ public class PeekConfig {
                 "SINGLE_TYPE: If the shulker box only contains one type of item, show that item",
                 "BULK: Show the item thats most common in the shulker box",
                 "FIRST_ITEM: Show the first item in the shulker box"
+        );
+        showShulkerBoxFillBar = builder.booleanEntry(
+                "show_shulker_box_fill_bar",
+                true,
+                "If this is enabled, shulker boxes in the inventory will show a fill bar indicating how full they are"
         );
         hideShulkerBoxDataStrings = builder.booleanEntry(
                 "hide_shulker_box_data_strings",

--- a/src/main/java/de/maxhenkel/peek/integration/ClothConfigIntegration.java
+++ b/src/main/java/de/maxhenkel/peek/integration/ClothConfigIntegration.java
@@ -122,6 +122,12 @@ public class ClothConfigIntegration {
                 Peek.CONFIG.showShulkerBoxLabels
         ));
 
+        shulkerBoxHints.addEntry(fromConfigEntry(entryBuilder,
+                Component.translatable("cloth_config.peek.show_shulker_box_fill_bar"),
+                Component.translatable("cloth_config.peek.show_shulker_box_fill_bar.description"),
+                Peek.CONFIG.showShulkerBoxFillBar
+        ));
+
         ConfigCategory decoratedPotHints = builder.getOrCreateCategory(Component.translatable("cloth_config.peek.category.decorated_pot_hints"));
 
         decoratedPotHints.addEntry(fromConfigEntry(entryBuilder,

--- a/src/main/java/de/maxhenkel/peek/mixin/BlockItemMixin.java
+++ b/src/main/java/de/maxhenkel/peek/mixin/BlockItemMixin.java
@@ -3,6 +3,8 @@ package de.maxhenkel.peek.mixin;
 import de.maxhenkel.peek.Peek;
 import de.maxhenkel.peek.events.TooltipImageEvents;
 import de.maxhenkel.peek.utils.ShulkerBoxUtils;
+import net.minecraft.core.NonNullList;
+import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.BlockItem;
@@ -11,6 +13,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.ShulkerBoxBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity;
 import org.spongepowered.asm.mixin.Final;
@@ -37,6 +40,36 @@ public abstract class BlockItemMixin extends Item {
     @Override
     public Optional<TooltipComponent> getTooltipImage(ItemStack stack) {
         return TooltipImageEvents.getTooltipImage(stack, block).or(() -> super.getTooltipImage(stack));
+    }
+
+    @Override
+    public boolean isBarVisible(ItemStack stack) {
+        if (Peek.CONFIG.showShulkerBoxFillBar.get() && block instanceof ShulkerBoxBlock) {
+            NonNullList<ItemStack> items = ShulkerBoxUtils.getItems(stack);
+            return items.stream().anyMatch(s -> !s.isEmpty());
+        }
+        return super.isBarVisible(stack);
+    }
+
+    @Override
+    public int getBarWidth(ItemStack stack) {
+        if (Peek.CONFIG.showShulkerBoxFillBar.get() && block instanceof ShulkerBoxBlock) {
+            NonNullList<ItemStack> items = ShulkerBoxUtils.getItems(stack);
+            long occupied = items.stream().filter(s -> !s.isEmpty()).count();
+            return Math.round((float) occupied / (float) items.size() * 13.0F);
+        }
+        return super.getBarWidth(stack);
+    }
+
+    @Override
+    public int getBarColor(ItemStack stack) {
+        if (Peek.CONFIG.showShulkerBoxFillBar.get() && block instanceof ShulkerBoxBlock) {
+            NonNullList<ItemStack> items = ShulkerBoxUtils.getItems(stack);
+            long occupied = items.stream().filter(s -> !s.isEmpty()).count();
+            float fillFraction = (float) occupied / (float) items.size();
+            return Mth.hsvToRgb((1.0F - fillFraction) / 3.0F, 1.0F, 1.0F);
+        }
+        return super.getBarColor(stack);
     }
 
     @Inject(method = "place", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;gameEvent(Lnet/minecraft/core/Holder;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/gameevent/GameEvent$Context;)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)

--- a/src/main/resources/assets/peek/lang/de_de.json
+++ b/src/main/resources/assets/peek/lang/de_de.json
@@ -54,6 +54,8 @@
   "cloth_config.peek.shulker_box_item_display_type.first_item.description": "Zeigt den ersten Gegenstand in der Shulker-Kiste an",
   "cloth_config.peek.show_shulker_box_labels": "Shulker-Kisten Namen anzeigen",
   "cloth_config.peek.show_shulker_box_labels.description": "Ob der Mod den benutzerdefinierten Namen der Shulker-Box auf dem Deckel der Shulker Box anzeigen soll.",
+  "cloth_config.peek.show_shulker_box_fill_bar": "Füllstandsanzeige für Shulker-Kisten anzeigen",
+  "cloth_config.peek.show_shulker_box_fill_bar.description": "Wenn aktiviert, zeigen Shulker-Kisten im Inventar eine Füllstandsanzeige an.",
   "cloth_config.peek.show_decorated_pot_hint": "Hinweis für verzierte Krüge anzeigen",
   "cloth_config.peek.show_decorated_pot_hint.description": "Ob Informationen zum Gegenstand in dekorierten Krügen angezeigt werden sollen."
 }

--- a/src/main/resources/assets/peek/lang/en_us.json
+++ b/src/main/resources/assets/peek/lang/en_us.json
@@ -54,6 +54,8 @@
   "cloth_config.peek.shulker_box_item_display_type.first_item.description": "Show the first item in the shulker box",
   "cloth_config.peek.show_shulker_box_labels": "Show Shulker Box Labels",
   "cloth_config.peek.show_shulker_box_labels.description": "If this is enabled, the mod will show the custom name of the Shulker Box on the lid of the shulker box.",
+  "cloth_config.peek.show_shulker_box_fill_bar": "Show Shulker Box Fill Bar",
+  "cloth_config.peek.show_shulker_box_fill_bar.description": "If this is enabled, shulker boxes in the inventory will show a fill bar indicating how full they are.",
   "cloth_config.peek.show_decorated_pot_hint": "Show Decorated Pot Hint",
   "cloth_config.peek.show_decorated_pot_hint.description": "If this is enabled, decorated pots will show the contained item and amount."
 }


### PR DESCRIPTION
This option allows players to display a fill bar on their shulker boxes when in inventory or chests.

Bar is green when shulker is almost empty, and gets red when shulker is full.

<img width="1876" height="536" alt="image" src="https://github.com/user-attachments/assets/094fbf52-e17a-45b9-a5a8-06db67d29739" />

<img width="115" height="60" alt="image" src="https://github.com/user-attachments/assets/43daba7c-9af9-4363-927d-8f82906680df" />
